### PR TITLE
Refact: 데이터 저장 예외처리 추가, 에러 수정

### DIFF
--- a/back/luckybocky/src/main/java/com/project/luckybocky/article/controller/CommentController.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/article/controller/CommentController.java
@@ -1,9 +1,9 @@
 package com.project.luckybocky.article.controller;
 
-import com.project.luckybocky.article.dto.ArticleResponseDto;
 import com.project.luckybocky.article.dto.CommentDto;
 import com.project.luckybocky.article.service.ArticleService;
-import com.project.luckybocky.common.MessageDto;
+import com.project.luckybocky.common.ResponseDto;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -18,9 +18,9 @@ public class CommentController {
     private final ArticleService articleService;
 
     @PostMapping
-    public ResponseEntity<MessageDto> writeComment(@RequestBody CommentDto commentDto){
+    public ResponseEntity<ResponseDto> writeComment(@RequestBody CommentDto commentDto){
         articleService.updateComment(commentDto);
-        return ResponseEntity.status(HttpStatus.OK).body(new MessageDto("success", "답변 작성 성공"));
+        return ResponseEntity.status(HttpStatus.OK).body(new ResponseDto("답변 작성 성공"));
     }
 
 }

--- a/back/luckybocky/src/main/java/com/project/luckybocky/common/GlobalExceptionHandler.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/common/GlobalExceptionHandler.java
@@ -1,11 +1,12 @@
 package com.project.luckybocky.common;
 
-import com.google.api.Http;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.project.luckybocky.article.exception.ArticleNotFoundException;
 import com.project.luckybocky.article.exception.CommentConflictException;
+import com.project.luckybocky.feedback.exception.FeedbackSaveException;
 import com.project.luckybocky.fortune.exception.FortuneNotFoundException;
 import com.project.luckybocky.pocket.exception.PocketNotFoundException;
+import com.project.luckybocky.report.exception.ReportSaveException;
 import com.project.luckybocky.user.exception.ForbiddenUserException;
 import com.project.luckybocky.auth.exception.LoginFailedException;
 import com.project.luckybocky.feedback.exception.FeedbackNotFoundException;
@@ -92,6 +93,18 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(LoginFailedException.class)
     public ResponseEntity<ResponseDto> handleLoginFailedException(LoginFailedException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(new ResponseDto(ex.getMessage()));
+    }
+
+    @ExceptionHandler(ReportSaveException.class)
+    public ResponseEntity<ResponseDto> handleReportSaveException(ReportSaveException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ResponseDto("Report save error: " + ex.getMessage()));
+    }
+
+    @ExceptionHandler(FeedbackSaveException.class)
+    public ResponseEntity<ResponseDto> handleFeedbackSaveException(FeedbackSaveException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ResponseDto("Feedback save error: " + ex.getMessage()));
     }
     //===== 우재 예외 추가 end ======
 }

--- a/back/luckybocky/src/main/java/com/project/luckybocky/feedback/controller/FeedbackController.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/feedback/controller/FeedbackController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.project.luckybocky.common.DataResponseDto;
 import com.project.luckybocky.common.ResponseDto;
-import com.project.luckybocky.feedback.dto.FeedbackDto;
 import com.project.luckybocky.feedback.dto.FeedbackReqDto;
 import com.project.luckybocky.feedback.dto.FeedbackResDto;
 import com.project.luckybocky.feedback.service.FeedbackService;

--- a/back/luckybocky/src/main/java/com/project/luckybocky/feedback/exception/FeedbackSaveException.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/feedback/exception/FeedbackSaveException.java
@@ -1,0 +1,7 @@
+package com.project.luckybocky.feedback.exception;
+
+public class FeedbackSaveException extends RuntimeException {
+	public FeedbackSaveException(String message) {
+		super(message);
+	}
+}

--- a/back/luckybocky/src/main/java/com/project/luckybocky/feedback/service/FeedbackService.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/feedback/service/FeedbackService.java
@@ -11,6 +11,7 @@ import com.project.luckybocky.feedback.dto.FeedbackResDto;
 import com.project.luckybocky.feedback.entity.Feedback;
 import com.project.luckybocky.feedback.exception.FeedbackNotFoundException;
 import com.project.luckybocky.common.SessionNotFoundException;
+import com.project.luckybocky.feedback.exception.FeedbackSaveException;
 import com.project.luckybocky.feedback.repository.FeedbackRepository;
 import com.project.luckybocky.user.entity.User;
 import com.project.luckybocky.user.exception.UserNotFoundException;
@@ -40,13 +41,17 @@ public class FeedbackService {
 		User user = userRepository.findByUserKey(userKey)
 			.orElseThrow(() -> new UserNotFoundException("User not found with key"));
 
-		feedbackRepository.save(
-			Feedback.builder()
-				.user(user)
-				.feedbackContent(feedbackReqDto.getFeedbackContent())
-				.feedbackRate(feedbackReqDto.getFeedbackRate())
-				.build()
-		);
+		try {
+			feedbackRepository.save(
+				Feedback.builder()
+					.user(user)
+					.feedbackContent(feedbackReqDto.getFeedbackContent())
+					.feedbackRate(feedbackReqDto.getFeedbackRate())
+					.build()
+			);
+		} catch (Exception e) {
+			throw new FeedbackSaveException(e.getMessage());
+		}
 	}
 
 	public FeedbackResDto getFeedback() {

--- a/back/luckybocky/src/main/java/com/project/luckybocky/report/controller/ReportController.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/report/controller/ReportController.java
@@ -11,7 +11,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.project.luckybocky.common.DataResponseDto;
 import com.project.luckybocky.common.ResponseDto;
-import com.project.luckybocky.report.dto.ReportDto;
 import com.project.luckybocky.report.dto.ReportReqDto;
 import com.project.luckybocky.report.dto.ReportResDto;
 import com.project.luckybocky.report.service.ReportService;

--- a/back/luckybocky/src/main/java/com/project/luckybocky/report/exception/ReportSaveException.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/report/exception/ReportSaveException.java
@@ -1,0 +1,7 @@
+package com.project.luckybocky.report.exception;
+
+public class ReportSaveException extends RuntimeException {
+	public ReportSaveException(String message) {
+		super(message);
+	}
+}

--- a/back/luckybocky/src/main/java/com/project/luckybocky/report/service/ReportService.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/report/service/ReportService.java
@@ -14,6 +14,7 @@ import com.project.luckybocky.report.dto.ReportReqDto;
 import com.project.luckybocky.report.dto.ReportResDto;
 import com.project.luckybocky.report.entity.Report;
 import com.project.luckybocky.report.exception.ReportNotFoundException;
+import com.project.luckybocky.report.exception.ReportSaveException;
 import com.project.luckybocky.report.repository.ReportRepository;
 import com.project.luckybocky.user.entity.User;
 import com.project.luckybocky.user.exception.UserNotFoundException;
@@ -43,13 +44,17 @@ public class ReportService {
 		Article article = articleRepository.findByArticleSeq(reportReqDto.getArticleSeq())
 			.orElseThrow(() -> new ArticleNotFoundException(reportReqDto.getArticleSeq() + " Article not found"));
 
-		reportRepository.save(
-			Report.builder()
-				.article(article)
-				.user(user)
-				.reportType(reportReqDto.getReportType())
-				.reportContent(reportReqDto.getReportContent())
-				.build());
+		try {
+			reportRepository.save(
+				Report.builder()
+					.article(article)
+					.user(user)
+					.reportType(reportReqDto.getReportType())
+					.reportContent(reportReqDto.getReportContent())
+					.build());
+		} catch (Exception e) {
+			throw new ReportSaveException(e.getMessage());
+		}
 	}
 
 	public ReportResDto getReport() {


### PR DESCRIPTION
* 특이 사항
  * CommentController MessageDto 에러 ResponseDto로 수정해서 해결
      * 제 담당 아니라서, 추후 담당자 확인 후 조치바람
  * JPA Save try catch 예외 처리 추가
      * 저장 단계에서 어떤 에러 발생할지 감도 안 잡혀서 그냥 모든 error 캐치해서 발생하는 에러 메시지 넘김
      * 단 식별을 위해 ~save error: 라고 앞에 붙여둠