### PR TITLE
Fix: modified_at 컬럼 변경되지 않는 문제 수정

### DIFF
--- a/back/luckybocky/src/main/java/com/project/luckybocky/common/BaseEntity.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/common/BaseEntity.java
@@ -20,7 +20,6 @@ public class BaseEntity {
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column()
     private LocalDateTime modifiedAt;
 
     @ColumnDefault("false")

--- a/back/luckybocky/src/main/java/com/project/luckybocky/common/BaseEntity.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/common/BaseEntity.java
@@ -20,7 +20,7 @@ public class BaseEntity {
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(updatable = false)
+    @Column()
     private LocalDateTime modifiedAt;
 
     @ColumnDefault("false")


### PR DESCRIPTION
* 진행 상황
  * modified_at이 변경되지 않았던 이유
    * BaseEntity에  modifiedAt에 어노테이션 설정이 @Column(updatable = false)으로 돼 있었습니다.
    * 기본값으로 돌려놓음으로써 해결했습니다.
- ~~특이사항~~
  - ~~컬럼 어노테이션 생략해 놓으려다가 확인차 일단 남겨두긴 했는데... 승인 전에 말씀해주시면 해당 브랜치에 생략해서 다시 올리겠습니다.~~