### PR TITLE
Feat : 비회원 처리

### DIFF
--- a/back/luckybocky/src/main/java/com/project/luckybocky/user/controller/SettingController.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/user/controller/SettingController.java
@@ -14,6 +14,7 @@ import com.project.luckybocky.common.ResponseDto;
 import com.project.luckybocky.user.dto.FirebaseKeyRequest;
 import com.project.luckybocky.user.dto.SettingDto;
 import com.project.luckybocky.user.dto.UserInfoDto;
+import com.project.luckybocky.user.dto.UserLoginDto;
 import com.project.luckybocky.user.exception.UserNotFoundException;
 import com.project.luckybocky.user.service.UserSettingService;
 
@@ -67,11 +68,11 @@ public class SettingController {
 			content = @Content(schema = @Schema(implementation = UserNotFoundException.class)))
 	})
 	@GetMapping("/user")
-	public ResponseEntity<DataResponseDto<UserInfoDto>> loadUserInfo(HttpSession session) {
+	public ResponseEntity<DataResponseDto<UserLoginDto>> loadUserInfo(HttpSession session) {
 		String userKey = (String)session.getAttribute("user");
-		UserInfoDto userInfoDto = userSettingService.getUserInfo(userKey);
-		log.info("사용자 조회 {}", userKey);
-		return ResponseEntity.status(HttpStatus.OK).body(new DataResponseDto<>("success", userInfoDto));
+
+		UserLoginDto userLoginDto = userSettingService.getUserLogin(userKey);
+		return ResponseEntity.status(HttpStatus.OK).body(new DataResponseDto<>("success", userLoginDto));
 	}
 
 	@Description("firebase Key 업데이트")
@@ -90,7 +91,7 @@ public class SettingController {
 		String userKey = (String)session.getAttribute("user");
 
 		String firebaseKey = firebaseKeyRequest.getFirebaseKey();
-		log.info("파이어베이스키를 업데이트 합니다. {} : 키 길이({})", userKey, firebaseKeyRequest.getFirebaseKey().length());
+
 		userSettingService.updateFireBaseKey(userKey, firebaseKey);
 		return ResponseEntity.status(HttpStatus.OK).body(new ResponseDto("success"));
 

--- a/back/luckybocky/src/main/java/com/project/luckybocky/user/dto/UserInfoDto.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/user/dto/UserInfoDto.java
@@ -2,9 +2,11 @@ package com.project.luckybocky.user.dto;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Builder
 @Getter
+@ToString
 public class UserInfoDto {
     private String userNickname;
     private boolean alarmStatus;

--- a/back/luckybocky/src/main/java/com/project/luckybocky/user/dto/UserLoginDto.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/user/dto/UserLoginDto.java
@@ -1,0 +1,21 @@
+package com.project.luckybocky.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+@Builder
+@Getter
+@ToString
+@AllArgsConstructor
+public class UserLoginDto {
+	private UserInfoDto userInfo;
+
+	private boolean isLogin;
+
+
+
+}

--- a/back/luckybocky/src/main/java/com/project/luckybocky/user/entity/User.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/user/entity/User.java
@@ -6,6 +6,7 @@ import com.project.luckybocky.feedback.entity.Feedback;
 import com.project.luckybocky.pocket.entity.Pocket;
 import com.project.luckybocky.report.entity.Report;
 import com.project.luckybocky.user.dto.UserInfoDto;
+import com.project.luckybocky.user.dto.UserLoginDto;
 
 import jakarta.persistence.*;
 import lombok.*;
@@ -91,6 +92,17 @@ public class User extends BaseEntity {
 			.createdAt(formattedDate)
 			.build();
 	}
+
+
+	public UserLoginDto getMemberInfo(){
+		UserInfoDto userInfoDto = getUserInfo();
+		return new UserLoginDto(userInfoDto, true);
+	}
+
+	public static UserLoginDto getNonMemberInfo(){
+		return new UserLoginDto(null, false);
+	}
+
 	//=====창희 dto 함수 end
 
 }

--- a/back/luckybocky/src/main/java/com/project/luckybocky/user/exception/UserNotFoundException.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/user/exception/UserNotFoundException.java
@@ -1,12 +1,8 @@
 package com.project.luckybocky.user.exception;
 
-import org.springframework.http.HttpStatus;
-
 import com.project.luckybocky.common.CustomException;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
 
 @Getter
 public class UserNotFoundException extends CustomException {

--- a/back/luckybocky/src/main/java/com/project/luckybocky/user/service/UserSettingService.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/user/service/UserSettingService.java
@@ -1,6 +1,7 @@
 package com.project.luckybocky.user.service;
 
 import com.project.luckybocky.user.dto.UserInfoDto;
+import com.project.luckybocky.user.dto.UserLoginDto;
 import com.project.luckybocky.user.entity.User;
 
 import java.util.Optional;
@@ -8,7 +9,7 @@ import java.util.Optional;
 public interface UserSettingService {
 
     void updateUserSetting(String userKey,String userNickname, boolean alarmStatus,boolean fortuneVisibility);
-    UserInfoDto getUserInfo(String userKey);
+    UserLoginDto getUserLogin(String userKey);
     Optional<User> findUserFirebaseKey(String userKey);
 
     void updateFireBaseKey(String userKey, String firebaseKey);

--- a/back/luckybocky/src/main/java/com/project/luckybocky/user/service/UserSettingServiceImpl.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/user/service/UserSettingServiceImpl.java
@@ -42,14 +42,13 @@ public class UserSettingServiceImpl implements UserSettingService {
 
 		//로그인이 되어있지 않는경우
 		if (userOptional.isEmpty()) {
-			// return User.getNonMemberInfo();
-			log.info("사용자 조회 null");
-			throw new UserNotFoundException();
+			log.info("비회원 입니다. 정보를 조회할 수 없습니다.");
+			return User.getNonMemberInfo();
 		}
 
 		User user = userOptional.get();
 
-		log.info("사용자 조회 {}", user.getMemberInfo());
+		log.info("회원정보를 조회합니다. {}", user.getMemberInfo());
 
 		return user.getMemberInfo();
 	}

--- a/back/luckybocky/src/main/java/com/project/luckybocky/user/service/UserSettingServiceImpl.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/user/service/UserSettingServiceImpl.java
@@ -1,6 +1,7 @@
 package com.project.luckybocky.user.service;
 
 import com.project.luckybocky.user.dto.UserInfoDto;
+import com.project.luckybocky.user.dto.UserLoginDto;
 import com.project.luckybocky.user.entity.User;
 import com.project.luckybocky.user.exception.UserNotFoundException;
 import com.project.luckybocky.user.repository.UserSettingRepository;
@@ -36,17 +37,21 @@ public class UserSettingServiceImpl implements UserSettingService {
 	}
 
 	@Override
-	public UserInfoDto getUserInfo(String userKey) {
+	public UserLoginDto getUserLogin(String userKey) {
 		Optional<User> userOptional = userSettingRepository.findByKey(userKey);
 
+		//로그인이 되어있지 않는경우
 		if (userOptional.isEmpty()) {
+			// return User.getNonMemberInfo();
+			log.info("사용자 조회 null");
 			throw new UserNotFoundException();
 		}
 
 		User user = userOptional.get();
-		log.info("findByUserKey {}", user);
 
-		return user.getUserInfo();
+		log.info("사용자 조회 {}", user.getMemberInfo());
+
+		return user.getMemberInfo();
 	}
 
 	@Override
@@ -54,9 +59,11 @@ public class UserSettingServiceImpl implements UserSettingService {
 		Optional<User> userOptional = userSettingRepository.findByKey(userKey);
 
 		if (userOptional.isEmpty()) {
+			log.info("사용자를 찾을 수 없어, 파이어베이스 키를 업데이트 할 수 없습니다.");
 			throw new UserNotFoundException();
 		}
 
+		log.info("파이어베이스키를 업데이트 합니다. {} : 키 길이({})", userKey, firebaseKey.length());
 		User user = userOptional.get();
 		user.setFirebaseKey(firebaseKey);
 	}


### PR DESCRIPTION
1. 회원정보 조회시(get(auth/user) dto변경
 
기존
data : {UserInfoDto : {}}

변경
data : {
             UserLoginDto: {
                                         UserInfoDto : {}, 
                                         login : boolean
                                         }
          }

[비회원일 경우 UserInfoDto이 null login이 false 입니다.] 
[회원일 경우 UserInfoDto에 값이 있고 login이 true입니다.]

백엔드에서 내려주는 데이터형식이 변경되어서 현재 로그인이 정상적으로 동작하지 않습니다.