### PR TITLE
Fix: 게시글 별 비밀글 로직 제거

### DIFF
--- a/back/luckybocky/src/main/java/com/project/luckybocky/article/dto/WriteArticleDto.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/article/dto/WriteArticleDto.java
@@ -20,6 +20,4 @@ public class WriteArticleDto {
 	private String content;
 	@Schema(description = "복 번호")   // ** 이거 fortuneImg가 번호로 바뀌면서, fortuneImg를 주는 거랑 다른게 없어졌음
 	private int fortuneSeq;
-	@Schema(description = "게시글 공개여부")
-	private boolean visibility;
 }

--- a/back/luckybocky/src/main/java/com/project/luckybocky/article/service/ArticleService.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/article/service/ArticleService.java
@@ -41,15 +41,15 @@ public class ArticleService {
 
 		ArticleResponseDto response = article.toArticleResponseDto();
 
-		if (userKey == null || !userKey.equals(article.getPocket().getUser().getUserKey())) {    // 복주머니의 주인이 아닐경우
-			// 비공개 복주머니나 비공개 글인 경우 -> 전부 비공개로 설정
-			if (!article.getPocket().getUser().isFortuneVisibility() || !article.isArticleVisibility()) {
+		if (userKey == null || !userKey.equals(article.getPocket().getUser().getUserKey())) {
+			// 복주머니 주인이 아니고, 비공개 복주머니일 경우 -> 게시글 전체 비공개 설정
+			if (!article.getPocket().getUser().isFortuneVisibility()) {
 				response.setArticleVisibility(false);
 				response.setArticleContent("비밀글입니다.");
 				response.setArticleComment("비밀글입니다.");
 			}
 		}
-		//복주머니 주인의 경우 -> 비밀글 설정을 다 공개로 바꿈
+		// 복주머니 주인 -> 게시글 전체 공개 설정
 		else {
 			response.setArticleVisibility(true);
 		}
@@ -71,9 +71,9 @@ public class ArticleService {
 
 	public void createArticle(String userKey, WriteArticleDto writeArticleDto) {
 		Optional<User> user = userRepository.findByUserKey(userKey);
-		//        if (user.isEmpty()){
-		//            throw new IllegalArgumentException("Invalid userKey: " + userKey);
-		//        }
+		// if (user.isEmpty()){
+		//    throw new IllegalArgumentException("Invalid userKey: " + userKey);
+		// }
 
 		Fortune fortune = fortuneRepository.findByFortuneSeq(writeArticleDto.getFortuneSeq())
 			.orElseThrow(() -> new FortuneNotFoundException());
@@ -86,7 +86,6 @@ public class ArticleService {
 			.userNickname(writeArticleDto.getNickname())
 			.articleContent(writeArticleDto.getContent())
 			.articleComment(null)
-			.articleVisibility(writeArticleDto.isVisibility())
 			.fortune(fortune)
 			.pocket(pocket)
 			.build();

--- a/back/luckybocky/src/main/java/com/project/luckybocky/article/service/ArticleService.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/article/service/ArticleService.java
@@ -93,7 +93,6 @@ public class ArticleService {
 			.userNickname(writeArticleDto.getNickname())
 			.articleContent(writeArticleDto.getContent())
 			.articleComment(null)
-			.articleVisibility(writeArticleDto.isVisibility())
 			.fortune(fortune)
 			.pocket(pocket)
 			.build();

--- a/back/luckybocky/src/main/java/com/project/luckybocky/pocket/controller/PocketController.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/pocket/controller/PocketController.java
@@ -64,16 +64,8 @@ public class PocketController {
 		PocketInfoDto findPocket = pocketService.getPocketInfo(url);
 		pocketDto.setPocketSeq(findPocket.getPocketSeq());
 		pocketDto.setUserNickname(findPocket.getUserNickname());
-
-		//        if (userKey == findPocket.getUserKey()){    // 복주머니 주인의 경우 (모든 게시글을 볼 수 있어야 함)
+		pocketDto.setFortuneVisibility(findPocket.isFortuneVisibility());
 		pocketDto.setArticles(articleService.getAllArticles(findPocket.getPocketSeq()));
-		//        } else {        // 복주머니의 주인이 아닐경우
-		//            if (!findPocket.isFortuneVisibility()){     // 비공개 복주머니일 경우 -> 전부 비공개로 설정
-		//                pocketDto.setArticles(articleService.getAllArticlesInvisible(findPocket.getPocketSeq()));
-		//            } else {    // 비공개 복주머니가 아닐 경우 -> 비공개 글만 비공개로 설정
-		//                pocketDto.setArticles(articleService.getAllArticlesCheck(findPocket.getPocketSeq()));
-		//            }
-		//        }
 
 		return ResponseEntity.status(HttpStatus.OK).body(new DataResponseDto<>("success", pocketDto));
 	}

--- a/back/luckybocky/src/main/java/com/project/luckybocky/pocket/dto/PocketDto.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/pocket/dto/PocketDto.java
@@ -15,6 +15,8 @@ public class PocketDto {
 	private int pocketSeq;
 	@Schema(description = "복주머니 주인 닉네임")
 	private String userNickname;
+	@Schema(description = "복주머니 공개여부")
+	private boolean fortuneVisibility;
 	@Schema(description = "복주머니에 달린 복")
 	private List<ArticleSummaryDto> articles;
 }


### PR DESCRIPTION
1. 게시글 가져올 때 - ArticleService.getArticleDetails()
    - 수정 전: 비공개 복주머니나 비공개 글인 경우 -> 전부 비공개로 설정
    - 수정 후: 비공개 복주머니일 경우 -> 게시글 전체 비공개 설정
2. WriteArticleDto - visibility 삭제
3. 복주머니 가져올 때, 복주머니 자체의 공개여부도 추가로 조회