### PR TITLE
Feat : 공유게시글 조회 수정

### DIFF
--- a/back/luckybocky/src/main/java/com/project/luckybocky/article/entity/Article.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/article/entity/Article.java
@@ -76,6 +76,10 @@ public class Article extends BaseEntity {
 	@JoinColumn(name = "pocket_seq")
 	private Pocket pocket;
 
+	public void setPocket(Pocket pocket) {
+		this.pocket = pocket;
+	}
+
 	public ArticleSummaryDto summaryArticle() {
 		return ArticleSummaryDto.builder()
 			.articleSeq(this.articleSeq)
@@ -147,4 +151,6 @@ public class Article extends BaseEntity {
 			.createdAt(this.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
 			.build();
 	}
+
+	//연관관계 펀의 메서드
 }

--- a/back/luckybocky/src/main/java/com/project/luckybocky/pocket/entity/Pocket.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/pocket/entity/Pocket.java
@@ -52,4 +52,10 @@ public class Pocket extends BaseEntity {
 	//    public void updateAddress(String pocketAddress){
 	//        this.pocketAddress = pocketAddress;
 	//    }
+
+	//연관관계 편의 메소드
+	public void addArticle(Article article) {
+		articles.add(article);
+		article.setPocket(this);
+	}
 }

--- a/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/controller/ShareArticleController.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/controller/ShareArticleController.java
@@ -2,6 +2,9 @@ package com.project.luckybocky.sharearticle.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.Mapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -41,23 +44,21 @@ public class ShareArticleController {
 	}
 
 	//공유게시글을 조회했을때 비회원은 로그인 창으로, 회원은 저장 처리
-	@PostMapping("/save")
-	public ResponseEntity<DataResponseDto<ShareArticleLoginDto>> enterShareArticle(HttpSession session, @RequestBody
-	ShareArticleAddressDto shareArticleAddressDto) {
+	@GetMapping("/{address}")
+	public ResponseEntity<DataResponseDto<ShareArticleLoginDto>> enterShareArticle(HttpSession session, @PathVariable String address) {
 		// String userKey = "K3858126130";
 		String userKey = (String)session.getAttribute("user");
-		String shareArticleAddress = shareArticleAddressDto.getShareArticleAddress();
 
 		if (userKey == null) {
 			log.info("비회원의 공유게시글 찾기입니다.");
 
-			ShareArticleDto shareArticle = shareArticleService.findShareArticle(shareArticleAddress);
+			ShareArticleDto shareArticle = shareArticleService.findShareArticle(address);
 			ShareArticleLoginDto shareArticleLoginDto = new ShareArticleLoginDto(false, shareArticle);
 			return ResponseEntity.status(HttpStatus.OK).body(new DataResponseDto<>("success", shareArticleLoginDto));
 		} else {
 			log.info("회원의 공유게시글 찾기입니다. {}", userKey);
 
-			ShareArticleDto shareArticleDto = shareArticleService.enterShareArticle(userKey, shareArticleAddress);
+			ShareArticleDto shareArticleDto = shareArticleService.enterShareArticle(userKey, address);
 			ShareArticleLoginDto shareArticleLoginDto = new ShareArticleLoginDto(true, shareArticleDto);
 			return ResponseEntity.status(HttpStatus.OK).body(new DataResponseDto<>("success", shareArticleLoginDto));
 		}

--- a/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/controller/ShareArticleController.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/controller/ShareArticleController.java
@@ -1,7 +1,5 @@
 package com.project.luckybocky.sharearticle.controller;
 
-import javax.swing.text.html.HTML;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,9 +8,9 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.luckybocky.common.DataResponseDto;
-import com.project.luckybocky.common.ResponseDto;
+import com.project.luckybocky.sharearticle.dto.ShareArticleAddressDto;
 import com.project.luckybocky.sharearticle.dto.ShareArticleDto;
-import com.project.luckybocky.sharearticle.dto.ShareArticleSeqDto;
+import com.project.luckybocky.sharearticle.dto.ShareArticleLoginDto;
 import com.project.luckybocky.sharearticle.dto.WriteShareArticleDto;
 import com.project.luckybocky.sharearticle.sevice.ShareArticleService;
 
@@ -36,7 +34,7 @@ public class ShareArticleController {
 		@RequestBody WriteShareArticleDto writeShareArticleDto) {
 		String userKey = (String)session.getAttribute("user");
 		// String userKey = "K3858126130";
-
+x
 		ShareArticleDto shareArticle = shareArticleService.createShareArticle(userKey, writeShareArticleDto);
 
 		return ResponseEntity.status(HttpStatus.OK).body(new DataResponseDto<ShareArticleDto>("success", shareArticle));
@@ -44,18 +42,26 @@ public class ShareArticleController {
 
 	//공유게시글을 조회했을때 비회원은 로그인 창으로, 회원은 저장 처리
 	@PostMapping("/save")
-	public ResponseEntity<DataResponseDto<Boolean>> enterShareArticle(HttpSession session, @RequestBody
-	ShareArticleSeqDto shareArticleSeqDto) {
+	public ResponseEntity<DataResponseDto<ShareArticleLoginDto>> enterShareArticle(HttpSession session, @RequestBody
+	ShareArticleAddressDto shareArticleAddressDto) {
 		// String userKey = "K3858126130";
 		String userKey = (String)session.getAttribute("user");
+		String shareArticleAddress = shareArticleAddressDto.getShareArticleAddress();
 
-		boolean isLogin = false;
-		if (userKey != null) {
-			isLogin = true;
-			int shareArticleSeq = shareArticleSeqDto.getShareArticleSeq();
-			shareArticleService.enterShareArticle(userKey, shareArticleSeq);
+		if (userKey == null) {
+			log.info("비회원의 공유게시글 찾기입니다.");
+
+			ShareArticleDto shareArticle = shareArticleService.findShareArticle(shareArticleAddress);
+			ShareArticleLoginDto shareArticleLoginDto = new ShareArticleLoginDto(false, shareArticle);
+			return ResponseEntity.status(HttpStatus.OK).body(new DataResponseDto<>("success", shareArticleLoginDto));
+		} else {
+			log.info("회원의 공유게시글 찾기입니다. {}", userKey);
+
+			ShareArticleDto shareArticleDto = shareArticleService.enterShareArticle(userKey, shareArticleAddress);
+			ShareArticleLoginDto shareArticleLoginDto = new ShareArticleLoginDto(true, shareArticleDto);
+			return ResponseEntity.status(HttpStatus.OK).body(new DataResponseDto<>("success", shareArticleLoginDto));
 		}
-		return ResponseEntity.status(HttpStatus.OK).body(new DataResponseDto<>("success", isLogin));
+
 	}
 
 }

--- a/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/controller/ShareArticleController.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/controller/ShareArticleController.java
@@ -34,7 +34,7 @@ public class ShareArticleController {
 		@RequestBody WriteShareArticleDto writeShareArticleDto) {
 		String userKey = (String)session.getAttribute("user");
 		// String userKey = "K3858126130";
-x
+
 		ShareArticleDto shareArticle = shareArticleService.createShareArticle(userKey, writeShareArticleDto);
 
 		return ResponseEntity.status(HttpStatus.OK).body(new DataResponseDto<ShareArticleDto>("success", shareArticle));

--- a/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/dto/ShareArticleAddressDto.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/dto/ShareArticleAddressDto.java
@@ -9,6 +9,6 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ShareArticleSeqDto {
-	int shareArticleSeq;
+public class ShareArticleAddressDto {
+	String shareArticleAddress;
 }

--- a/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/dto/ShareArticleLoginDto.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/dto/ShareArticleLoginDto.java
@@ -1,0 +1,16 @@
+package com.project.luckybocky.sharearticle.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShareArticleLoginDto{
+	boolean isLogin;
+	ShareArticleDto shareArticleDto;
+}

--- a/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/repository/ShareArticleRepository.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/repository/ShareArticleRepository.java
@@ -1,5 +1,7 @@
 package com.project.luckybocky.sharearticle.repository;
 
+import java.util.Optional;
+
 import org.springframework.stereotype.Repository;
 
 import com.project.luckybocky.sharearticle.entity.ShareArticle;
@@ -21,9 +23,10 @@ public class ShareArticleRepository {
 		return em.find(ShareArticle.class, shareArticleSeq);
 	}
 
-	// public Optional<User> findByKey(String userKey) {
-	// 	return em.createQuery("select u from User u where u.userKey=:userKey", User.class)
-	// 		.setParameter("userKey", userKey)
-	// 		.getResultList().stream().findAny();
-	// }
+	public Optional<ShareArticle> findByAddress(String shareArticleAddress) {
+		return em.createQuery(
+				"select s from ShareArticle s where s.shareArticleAddress=:shareArticleAddress", ShareArticle.class)
+			.setParameter("shareArticleAddress", shareArticleAddress)
+			.getResultList().stream().findAny();
+	}
 }

--- a/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/sevice/ShareArticleService.java
+++ b/back/luckybocky/src/main/java/com/project/luckybocky/sharearticle/sevice/ShareArticleService.java
@@ -2,20 +2,24 @@ package com.project.luckybocky.sharearticle.sevice;
 
 import com.project.luckybocky.sharearticle.dto.ShareArticleDto;
 import com.project.luckybocky.sharearticle.dto.WriteShareArticleDto;
+import com.project.luckybocky.sharearticle.entity.ShareArticle;
 
 public interface ShareArticleService {
 	//공유 게시글 생성
 	ShareArticleDto createShareArticle(String userKey, WriteShareArticleDto writeShareArticleDto);
 
-	//공유 게시글 조회
-	void enterShareArticle(String userKey, int shareArticleSeq);
+	//공유 게시글을 저장하기
+	ShareArticleDto enterShareArticle(String userKey, String shareArticleAddress);
+
+	//공유게시글을 uuid로 찾기
+	ShareArticleDto findShareArticle(String shareArticleAddress);
 
 
 	//본인 공유게시글인지 판단(본인의 공유게시글은 저장하지 않아야 하기 떄문에)
-	boolean isMyShareArticle(String userKey, int shareArticleSeq);
+	boolean isMyShareArticle(String userKey, ShareArticle shareArticle);
 
 
 	//저장하려는 유저가 이미 이 공유게시글을 저장한 경우
-	boolean isExistsShareArticle(String userKey, int shareArticleSeq);
+	boolean isExistsShareArticle(String userKey, ShareArticle shareArticle);
 
 }


### PR DESCRIPTION
공유게시글 조회 수정
1. 반환 데이터 변경 - shareArticleDto 와 로그인 여부를 나타내는 컬럼

회원이면 공유게시글을 uuid로만 조회하고 공유게시글을 복사해서 게시글에 추가한다. 그리고 연관관계매핑(shareArticle과 Article, Article과 Pocket)수행 후, login을 true로해서 반환

비회원이면 공유게시글을 uuid로만 조회하고 login은 false 반환
